### PR TITLE
Fix response packet size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vvidic/go-twamp
+module github.com/orn1983/twamp-server/v2
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/vvidic/go-twamp
+
+go 1.18
+
+require github.com/golang/glog v1.0.0

--- a/twamp-server.go
+++ b/twamp-server.go
@@ -526,10 +526,11 @@ func runReflector(conn *net.UDPConn, test_done chan bool) error {
 		req_len, addr, err := conn.ReadFromUDP(buf)
 		if err != nil {
 			if err, ok := err.(net.Error); ok && err.Timeout() {
-				if _, ok := <-test_done; !ok {
+				select {
+				case <-test_done:
 					glog.Infoln("Finished test session on port", conn.LocalAddr())
 					return nil
-				} else {
+				default:
 					glog.V(2).Infoln("Timeout waiting for test packet:", err)
 					continue
 				}

--- a/twamp-server.go
+++ b/twamp-server.go
@@ -425,9 +425,7 @@ func sendStartAck(conn net.Conn) error {
 	return nil
 }
 
-func createTestResponse(buf []byte, seq uint32) ([]byte, error) {
-	req_len := len(buf)
-
+func createTestResponse(buf []byte, seq uint32, req_len int) ([]byte, error) {
 	req := new(TestRequest)
 	reader := bytes.NewBuffer(buf)
 	err := binary.Read(reader, binary.BigEndian, req)
@@ -525,7 +523,7 @@ func runReflector(conn *net.UDPConn, test_done chan bool) error {
 			return fmt.Errorf("Error setting test deadline: %s", err)
 		}
 
-		_, addr, err := conn.ReadFromUDP(buf)
+		req_len, addr, err := conn.ReadFromUDP(buf)
 		if err != nil {
 			if err, ok := err.(net.Error); ok && err.Timeout() {
 				if _, ok := <-test_done; !ok {
@@ -540,7 +538,7 @@ func runReflector(conn *net.UDPConn, test_done chan bool) error {
 			return fmt.Errorf("Error receiving test packet: %s", err)
 		}
 
-		response, err := createTestResponse(buf, seq)
+		response, err := createTestResponse(buf, seq, req_len)
 		if err != nil {
 			return fmt.Errorf("Error creating test response: %s", err)
 		}


### PR DESCRIPTION
The size of the response packet was calculated by checking the length of the receive buffer. The buffer was created with a fixed size of 10240, so that was always the size of the response payload.

Now we store the value of bytes read from ReadFromUDP and pass it on to createTestResponse so that we can create a response packet of the same size as the request packet.